### PR TITLE
Fix PHP 8 incompatibilities

### DIFF
--- a/src/Danmichaelo/Coma/Lab.php
+++ b/src/Danmichaelo/Coma/Lab.php
@@ -6,7 +6,7 @@ class Lab
 {
     public $l;
     public $a;
-    public $n;
+    public $b;
 
     public function __construct($l, $a, $b)
     {

--- a/src/Danmichaelo/Coma/XYZ.php
+++ b/src/Danmichaelo/Coma/XYZ.php
@@ -7,6 +7,7 @@ class XYZ
     public $x;
     public $y;
     public $z;
+    private $white;
 
     public function __construct($x, $y, $z)
     {


### PR DESCRIPTION
Creation of dynamic property is deprecated in modern PHP 8. I think it was just a mistake in both cases as the rest of the code looks really good.

This is relevant for the magic border detection feature in https://croptool.toolforge.org that currently doesn't work because of this. @danmichaelo, do you think it's possible to release this and forward it to the CropTool codebase to see if this alone already solves the problem?